### PR TITLE
Fix link generator to handle default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
         run: npm run test:coverage
 
       - name: 🚀 Release
-        if: "contains(github.event.head_commit.message, 'release')" # do not release every time during 0.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/utarwyn/storybook-branch-switcher"
+    "url": "git+https://github.com/utarwyn/storybook-branch-switcher.git"
   },
   "license": "MIT",
   "author": "utarwyn <maxime.malgorn@laposte.net>",
   "bin": {
-    "sb-branch-switcher": "./dist/cli.mjs"
+    "sb-branch-switcher": "dist/cli.mjs"
   },
   "exports": {
     ".": {

--- a/src/util/location.spec.ts
+++ b/src/util/location.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { generateLink } from "./location";
+
+describe("location", () => {
+  describe("Method: generateLink", () => {
+    const location = {
+      protocol: "https:",
+      hostname: "company.design",
+      port: "443",
+      search: "",
+      hash: "",
+    } as Location;
+
+    test("should use current host by default", () => {
+      expect(generateLink(location, null, null, null, null)).toBe(
+        "https://company.design:443/",
+      );
+    });
+
+    test("should use targetHost if provided", () => {
+      expect(generateLink(location, "localhost:3000", null, null, null)).toBe(
+        "https://localhost:3000/",
+      );
+    });
+
+    test("should pass same search and hash params to target", () => {
+      const loc = { ...location, search: "?a=b", hash: "#c=d" };
+      expect(generateLink(loc, null, null, null, null)).toBe(
+        "https://company.design:443/?a=b#c=d",
+      );
+    });
+
+    test.each`
+      def         | current     | target      | expectedPath | description
+      ${"master"} | ${"master"} | ${"master"} | ${"/"}       | ${"target is the current branch"}
+      ${"master"} | ${"master"} | ${"PR-6"}   | ${"/PR-6/"}  | ${"target is not the default branch"}
+      ${"master"} | ${"PR-6"}   | ${"master"} | ${"/"}       | ${"target is the default branch"}
+      ${"master"} | ${"PR-6"}   | ${"PR-7"}   | ${"/PR-7/"}  | ${"target is neither the current branch nor the default one"}
+    `(
+      "should replace path if $description",
+      ({ def, current, target, expectedPath }) => {
+        const loc = { ...location, pathname: `/${current}/` };
+        expect(generateLink(loc, null, def, current, target)).toBe(
+          `https://company.design:443${expectedPath}`,
+        );
+      },
+    );
+  });
+});

--- a/src/util/location.ts
+++ b/src/util/location.ts
@@ -1,11 +1,19 @@
-export const generateLink = (location: Location, targetHost: string, def: string, current: string, target: string): string => {
+export const generateLink = (
+  location: Location,
+  targetHost: string,
+  def: string,
+  current: string,
+  target: string,
+): string => {
   const hostname = targetHost || `${location.hostname}:${location.port}`;
   let path: string;
 
-  if (current && def !== current) {
-    path = location.pathname.replace(current, target);
-  } else if (target && def !== target) {
-    path = `/${target}/`;
+  if (target !== def) {
+    if (current === def) {
+      path = `/${target}/`;
+    } else {
+      path = location.pathname.replace(current, target);
+    }
   } else {
     path = "/";
   }


### PR DESCRIPTION
There's currently a bug when you want to return to the default branch: the link is invalid. This PR corrects the problem.