### PR TITLE
Add support for subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,61 @@ You must set `GITLAB_TOKEN` environment variable to access the Gitlab.com API.
   }
 }
 ```
+
+## FAQ
+
+### How do I host my storybook in a subpath? (e.g. GitHub Pages)
+
+Out-of-the-box this addon supports hosting Storybook at the root path, but
+you'll need some extra setup if you'd like to host a storybook in a subpath.
+
+| ✅ Out-of-the-box: root path | 🛠️ Requires setup: subpaths                 |
+|:-----------------------------|:--------------------------------------------|
+| `http://localhost:6006`      | `http://localhost:6006/some/path`           |
+| `https://sub.example.com`   | `https://your-username.github.io/your-repo` |
+
+Just make these changes in your `.storybook/preview.js` file, in this example,
+publishing to GitHub Pages.
+
+<details>
+<summary>Click for example configuration...</summary>
+
+```diff
+diff --git a/.storybook/preview.js b/.storybook/preview.js
+index 6731af8..7587cb6 100644
+--- a/.storybook/preview.js
++++ b/.storybook/preview.js
+@@ -1,4 +1,5 @@
+ /** @type { import('@storybook/react').Preview } */
+ const preview = {
+   parameters: {
+     controls: {
+@@ -10,4 +11,18 @@ const preview = {
+   },
+ };
+ 
++/* Any envvar prefixed with STORYBOOK_ will be available in the built storybook, ie. preview.js
++ * See: https://storybook.js.org/docs/configure/environment-variables
++ *
++ * Set STORYBOOK_PUBLISH_FOR_WEB=true in your build environment, along with the
++ * domain and path you'd like to host from.
++ */
++if (process.env["STORYBOOK_PUBLISH_FOR_WEB"]) {
++  preview.parameters = {
++    branches: {
++      hostname: `your-username.github.io/your-repo`,
++    }
++  }
++}
++
+ export default preview;
+```
+</details>
+
+You'll then just need to set `STORYBOOK_PUBLISH_FOR_WEB=true` in whatever build
+environment you run the `sb-branch-switcher` command.
+
+To test locally:
+1. set `hostname` in `.storybook/preview.js` to `localhost:6006/storybook-bundle`,
+2. build via `STORYBOOK_PUBLISH_FOR_WEB=true sb-branch-switcher <other opts>`
+3. run `npx http-server dist` to serve your local storybook one subpath deeper.

--- a/src/components/branch-switcher.tsx
+++ b/src/components/branch-switcher.tsx
@@ -38,7 +38,6 @@ export const BranchSwitcher = () => {
           location,
           hostname,
           defaultBranch,
-          currentBranch,
           branch
         );
       }

--- a/src/util/location.spec.ts
+++ b/src/util/location.spec.ts
@@ -12,20 +12,20 @@ describe("location", () => {
     } as Location;
 
     test("should use current host by default", () => {
-      expect(generateLink(location, null, null, null, null)).toBe(
+      expect(generateLink(location, null, null, null)).toBe(
         "https://company.design:443/",
       );
     });
 
     test("should use targetHost if provided", () => {
-      expect(generateLink(location, "localhost:3000", null, null, null)).toBe(
+      expect(generateLink(location, "localhost:3000", null, null)).toBe(
         "https://localhost:3000/",
       );
     });
 
     test("should pass same search and hash params to target", () => {
       const loc = { ...location, search: "?a=b", hash: "#c=d" };
-      expect(generateLink(loc, null, null, null, null)).toBe(
+      expect(generateLink(loc, null, null, null)).toBe(
         "https://company.design:443/?a=b#c=d",
       );
     });
@@ -40,7 +40,7 @@ describe("location", () => {
       "should replace root path if $description",
       ({ def, current, target, expectedPath }) => {
         const loc = { ...location, pathname: `/${current}/` };
-        expect(generateLink(loc, null, def, current, target)).toBe(
+        expect(generateLink(loc, null, def, target)).toBe(
           `https://company.design:443${expectedPath}`,
         );
       },
@@ -57,7 +57,7 @@ describe("location", () => {
       ({ def, current, target, expectedPath }) => {
         const loc = { ...location, pathname: `/subpath/${current}` };
         const targetHost = "company.design:443/subpath"
-        expect(generateLink(loc, targetHost, def, current, target)).toBe(
+        expect(generateLink(loc, targetHost, def, target)).toBe(
           `https://company.design:443${expectedPath}`,
         );
       },

--- a/src/util/location.spec.ts
+++ b/src/util/location.spec.ts
@@ -37,10 +37,27 @@ describe("location", () => {
       ${"master"} | ${"PR-6"}   | ${"master"} | ${"/"}       | ${"target is the default branch"}
       ${"master"} | ${"PR-6"}   | ${"PR-7"}   | ${"/PR-7/"}  | ${"target is neither the current branch nor the default one"}
     `(
-      "should replace path if $description",
+      "should replace root path if $description",
       ({ def, current, target, expectedPath }) => {
         const loc = { ...location, pathname: `/${current}/` };
         expect(generateLink(loc, null, def, current, target)).toBe(
+          `https://company.design:443${expectedPath}`,
+        );
+      },
+    );
+
+    test.each`
+      def         | current     | target      | expectedPath         | description
+      ${"master"} | ${"master"} | ${"master"} | ${"/subpath/"}       | ${"target is the current branch"}
+      ${"master"} | ${"master"} | ${"PR-6"}   | ${"/subpath/PR-6/"}  | ${"target is not the default branch"}
+      ${"master"} | ${"PR-6"}   | ${"master"} | ${"/subpath/"}       | ${"target is the default branch"}
+      ${"master"} | ${"PR-6"}   | ${"PR-7"}   | ${"/subpath/PR-7/"}  | ${"target is neither the current branch nor the default one"}
+    `(
+      "should replace subpath via targetHost if $description",
+      ({ def, current, target, expectedPath }) => {
+        const loc = { ...location, pathname: `/subpath/${current}` };
+        const targetHost = "company.design:443/subpath"
+        expect(generateLink(loc, targetHost, def, current, target)).toBe(
           `https://company.design:443${expectedPath}`,
         );
       },

--- a/src/util/location.ts
+++ b/src/util/location.ts
@@ -2,7 +2,6 @@ export const generateLink = (
   location: Location,
   targetHost: string,
   def: string,
-  current: string,
   target: string,
 ): string => {
   const hostname = targetHost || `${location.hostname}:${location.port}`;

--- a/src/util/location.ts
+++ b/src/util/location.ts
@@ -9,11 +9,7 @@ export const generateLink = (
   let path: string;
 
   if (target !== def) {
-    if (current === def) {
-      path = `/${target}/`;
-    } else {
-      path = location.pathname.replace(current, target);
-    }
+    path = `/${target}/`;
   } else {
     path = "/";
   }


### PR DESCRIPTION
Resolves: https://github.com/utarwyn/storybook-branch-switcher/issues/9

Not documented yet, but only because I'm suspicious I solved it in the wrong way. Avoiding location.pathname.replace() in favour of just returnin `/${target}/` seems to resolve the issue as I've added tests for. The tests only broke with the logic we had before.

Will try on an actual site, but hoping this resolves the issue!