### PR TITLE
Add GitHub config url

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This provider enables you to generate one Storybook instance per opened PR of a 
 | type       | -       | **(mandatory)** must be **"github"**                    |
 | owner      | -       | **(mandatory)** name of the GitHub owner                |
 | repository | -       | **(mandatory)** name of the Github repository to target |
+| url        | https://api.github.com | Github host to connect                   |
 
 You must set `GITHUB_TOKEN` environment variable to access the GitHub.com API.
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ If the Bitbucket instance needs an authorization, you can use one of the followi
 
 This provider enables you to generate one Storybook instance per opened PR of a GitHub repository.
 
-| Key        | Default | Description                                             |
-| ---------- | ------- | ------------------------------------------------------- |
-| type       | -       | **(mandatory)** must be **"github"**                    |
-| owner      | -       | **(mandatory)** name of the GitHub owner                |
-| repository | -       | **(mandatory)** name of the Github repository to target |
-| url        | https://api.github.com | Github host to connect                   |
+| Key        | Default                | Description                                             |
+| ---------- | ---------------------- | ------------------------------------------------------- |
+| type       | -                      | **(mandatory)** must be **"github"**                    |
+| owner      | -                      | **(mandatory)** name of the GitHub owner                |
+| repository | -                      | **(mandatory)** name of the Github repository to target |
+| url        | https://api.github.com | Github host to connect                                  |
 
 You must set `GITHUB_TOKEN` environment variable to access the GitHub.com API.
 
@@ -118,9 +118,9 @@ Out-of-the-box this addon supports hosting Storybook at the root path, but
 you'll need some extra setup if you'd like to host a storybook in a subpath.
 
 | ✅ Out-of-the-box: root path | 🛠️ Requires setup: subpaths                 |
-|:-----------------------------|:--------------------------------------------|
+| :--------------------------- | :------------------------------------------ |
 | `http://localhost:6006`      | `http://localhost:6006/some/path`           |
-| `https://sub.example.com`   | `https://your-username.github.io/your-repo` |
+| `https://sub.example.com`    | `https://your-username.github.io/your-repo` |
 
 Just make these changes in your `.storybook/preview.js` file, in this example,
 publishing to GitHub Pages.
@@ -141,7 +141,7 @@ index 6731af8..7587cb6 100644
 @@ -10,4 +11,18 @@ const preview = {
    },
  };
- 
+
 +/* Any envvar prefixed with STORYBOOK_ will be available in the built storybook, ie. preview.js
 + * See: https://storybook.js.org/docs/configure/environment-variables
 + *
@@ -158,12 +158,14 @@ index 6731af8..7587cb6 100644
 +
  export default preview;
 ```
+
 </details>
 
 You'll then just need to set `STORYBOOK_PUBLISH_FOR_WEB=true` in whatever build
 environment you run the `sb-branch-switcher` command.
 
 To test locally:
+
 1. set `hostname` in `.storybook/preview.js` to `localhost:6006/storybook-bundle`,
 2. build via `STORYBOOK_PUBLISH_FOR_WEB=true sb-branch-switcher <other opts>`
 3. run `npx http-server dist` to serve your local storybook one subpath deeper.

--- a/src/run/providers/github-pull-requests.ts
+++ b/src/run/providers/github-pull-requests.ts
@@ -3,6 +3,7 @@ import type { BranchProvider } from "./index";
 
 export interface GithubProviderConfig extends ProviderConfig {
   type: "github";
+  url?: string;
   owner: string;
   repository: string;
 }
@@ -11,7 +12,8 @@ const isApplicable = (config: GithubProviderConfig) =>
   config.type === "github" && config.owner != null && config.repository != null;
 
 const fetcher = async (config: GithubProviderConfig) => {
-  const url = `https://api.github.com/repos/${config.owner}/${config.repository}/pulls?state=open`;
+  const host = config.url ?? "https://api.github.com";
+  const url = `${host}/repos/${config.owner}/${config.repository}/pulls?state=open`;
   const response = await fetch(url, {
     headers: {
       Accept: "Accept: application/vnd.github+json",


### PR DESCRIPTION
Updates Github implementation to allow for Enterprise urls to be configured.